### PR TITLE
feat: add new node versions for march 24th security updates, don't pin "24" to "24.13"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - BASE_IMAGE: "node:24.13-bookworm-slim"
+          - BASE_IMAGE: "node:24-bookworm-slim"
             TAG_VERSION: "24"
+          - BASE_IMAGE: "node:24.14-bookworm-slim"
+            TAG_VERSION: "24.14"
           - BASE_IMAGE: "node:24.13-bookworm-slim"
             TAG_VERSION: "24.13"
           - BASE_IMAGE: "node:24.11.1-bookworm-slim"
@@ -35,7 +37,7 @@ jobs:
             TAG_VERSION: "24.1"
           - BASE_IMAGE: "node:24.0-bookworm-slim"
             TAG_VERSION: "24.0"
-          - BASE_IMAGE: "node:22.22-bookworm-slim"
+          - BASE_IMAGE: "node:22-bookworm-slim"
             TAG_VERSION: "22"
           - BASE_IMAGE: "node:22.22-bookworm-slim"
             TAG_VERSION: "22.22"


### PR DESCRIPTION
## Context

A new node version came out for node 20, 22, 24

https://nodejs.org/en/blog/vulnerability/march-2026-security-releases

https://hub.docker.com/_/node

## Changes

- Loosely couple "24" to not pin on minor version
- Add 24.14 (resolving to 24.14.1 currently)
- Do not add 25 yet (-: